### PR TITLE
Run script from within tmux popups if possible

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -4,9 +4,18 @@ bind '"' split-window -c "#{pane_current_path}"
 bind % split-window -h -c "#{pane_current_path}"
 bind c new-window -c "#{pane_current_path}"
 setw -g mouse on
-bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe 'xclip -in -selection clipboard'
 #bind a send-keys python3 Space -c Space \' 'import pty;pty.spawn("/bin/bash")' \' Enter C-z 'stty size' Enter 'stty raw -echo; fg' Enter '' Enter 'stty rows 60 cols 235' Enter 'export TERM=xterm' Enter
 #bind y send-keys python Space -c Space \' 'import pty;pty.spawn("/bin/bash")' \' Enter C-z 'stty size' Enter 'stty raw -echo; fg' Enter '' Enter 'stty rows 60 cols 235' Enter 'export TERM=xterm' Enter
 #bind b run-shell "bash ~/get-ip-tmux.sh #{session_id} #{window_id} #{pane_id}"
 #bind b new-window "~/get-ip-tmux.sh #{session_id} #{window_id} #{pane_id}"
-bind b split-window -c "#{pane_current_path}" -h '~/tmux-ip-menu.py'
+
+# tmux IP menu bindings
+
+# for tmux < 3.2, run in a pane.
+# when running in a pane, the menu will have to ask you to select the current pane.
+#bind b split-window -c "#{pane_current_path}" -h '~/tmux-ip-menu.py'
+
+# for tmux >= 3.2, run in a popup. pass "popup" as command argument to let the script know this is how it's being run.
+# in popup mode, the command "tmux list-panes" displays the pane you were on before the popup appeared, so no selecting required
+bind b display-popup -E '~/tmux-ip-menu.py popup'


### PR DESCRIPTION
tmux popups can correctly identify the current tmux pane, so if the script is running in popup mode then you don't have to have a prompt in the script to select the current pane when sending text